### PR TITLE
Fix DisplayWidget docstring

### DIFF
--- a/src/led_kurokku/widgets/base.py
+++ b/src/led_kurokku/widgets/base.py
@@ -39,9 +39,10 @@ class DisplayWidget:
         config_event: asyncio.Event = None,
         config: WidgetConfig = None,
     ):
-        """
-        Initialize the BaseWidget with.
-        :param config_queue: An asyncio.Queue for receiving configuration updates.
+        """Initialize the DisplayWidget.
+
+        :param config_event: An ``asyncio.Event`` that signals configuration
+            changes.
         """
         self.config_event = config_event
         self.config = config


### PR DESCRIPTION
## Summary
- clarify initialization short description
- document `config_event` as an ``asyncio.Event`` signaling configuration changes

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68801bfca2d4832189b8c62f07d8ae83