### PR TITLE
Handle weather service termination signals

### DIFF
--- a/src/led_kurokku/cli/services/weather_service.py
+++ b/src/led_kurokku/cli/services/weather_service.py
@@ -4,6 +4,7 @@ Weather service for LED-Kurokku CLI server.
 
 import asyncio
 import json
+import signal
 from datetime import datetime
 
 from loguru import logger
@@ -350,6 +351,9 @@ def run_weather_service(config: WeatherConfig | None = None):
         def signal_handler():
             logger.info("Stopping weather service...")
             loop.create_task(service.stop())
+
+        loop.add_signal_handler(signal.SIGINT, signal_handler)
+        loop.add_signal_handler(signal.SIGTERM, signal_handler)
 
         # Start the service
         await service.start()


### PR DESCRIPTION
## Summary
- add missing signal import
- register SIGINT and SIGTERM handlers so `run_weather_service` stops gracefully

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68801bee73788321a39b8d27fcf03aad