### PR TITLE
Fix README bullet formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Widget types:
 * clock
   * configurable to show either 12/24 hour format.
     * when in 12 hour format (the colon blinks double while PM and single blink during AM).
-  * 
 * message
   * these can be static messages or dynamically loaded on display from a Redis compatible store. So if you have a separate process updating a temperature reading in redis, you can have a static message that displays that reading. 
 * alert


### PR DESCRIPTION
## Summary
- remove stray empty bullet in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68801bd97a2c8321a86e59ae07b4186b