### PR TITLE
Weather priorities and cron config standardization

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Or you can choose to use the virtual or real display but also log debug level ou
     * `widget_type` - one of `clock`, `alert`, `message`, `animation`
     * `enabled` - boolean (defaults to `true`)
     * `duration` - number of seconds to display (defaults to `5`)
+    * `cron` - an optional cron string to define when to display (example: `*/10 * * * *` only displays every 10 minutes)
     * *additional widget_type specific configuration options*
   * `brightness` - brightness settings
     * `begin` - time to begin high brightness (e.g. `08:00`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pyyaml>=6.0.1",
     "aiohttp>=3.8.5",
     "loguru>=0.7.3",
+    "pycron>=3.2.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "led-kurokku"
-version = "0.2.0"
+version = "0.3.0"
 readme = "README.md"
 authors = [{ name = "swilcox", email = "steven@wilcoxzone.com" }]
 requires-python = ">=3.11"

--- a/src/led_kurokku/cli/services/weather_service.py
+++ b/src/led_kurokku/cli/services/weather_service.py
@@ -233,13 +233,17 @@ class WeatherService:
                 # Set new alerts
                 for i, alert in enumerate(alerts):
                     redis_key = f"{REDIS_WEATHER_ALERT_KEY_PREFIX}{location.name}:{i}"
+                    
+                    # Determine priority based on event type
+                    alert_priority = self.config.get_alert_priority(alert["message"])
+                    
                     await client.set(
                         redis_key,
                         json.dumps(
                             {
                                 "timestamp": datetime.now().isoformat(),
                                 "message": alert["message"],
-                                "priority": 1,  # Higher priority than regular alerts
+                                "priority": alert_priority,
                                 "display_duration": (len(alert["message"]) * 0.3) + 3.0,
                                 "delete_after_display": False,
                             }

--- a/src/led_kurokku/widgets/alert.py
+++ b/src/led_kurokku/widgets/alert.py
@@ -3,6 +3,7 @@ import json
 from typing import Literal
 
 from pydantic import BaseModel
+import pycron
 
 from .base import DisplayWidget, WidgetConfig
 
@@ -67,6 +68,8 @@ class AlertWidget(DisplayWidget):
             alerts.sort(key=lambda x: (x.priority, x.timestamp))
 
             for alert in alerts:
+                if alert.priority == 10 and not pycron.is_now("*/10 * * * *"):
+                    continue  # Skip low-priority alerts if not the right time
                 if len(alert.message) <= self.tm.display_length:
                     self.tm.show_text(alert.message)
                     if await self._sleep_and_check_stop(alert.display_duration):

--- a/src/led_kurokku/widgets/animation.py
+++ b/src/led_kurokku/widgets/animation.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import json
 import logging
 from typing import Literal
@@ -27,25 +26,9 @@ class AnimationWidgetConfig(WidgetConfig):
     scroll_speed: float = 0.1
     repeat: bool = True
     sleep_before_repeat: float = 0.0
-    cron_minute: str | None = None
 
 
 class AnimationWidget(DisplayWidget):
-    def check_cron(self):
-        """
-        Check if the current minute matches the cron expression.
-        """
-        if self.config.cron_minute is None or self.config.cron_minute in ["", "*"]:
-            return True
-        if "/" in self.config.cron_minute:
-            # Handle cron expressions with step values
-            step = int(self.config.cron_minute.split("/")[1])
-            if datetime.now().minute % step != 0:
-                return False
-        elif int(self.config.cron_minute) != datetime.now().minute:
-            return False
-        return True
-
     async def display(self):
         logger.debug(f"AnimationWidget started with config: {self.config}")
         if not self.check_cron():

--- a/src/led_kurokku/widgets/message.py
+++ b/src/led_kurokku/widgets/message.py
@@ -26,6 +26,9 @@ class MessageWidget(DisplayWidget):
         self,
     ):
         logger.debug(f"MessageWidget started with config: {self.config}")
+        if not self.check_cron():
+            logger.debug("Cron minute check failed, skipping display.")
+            return
         while self.okay_to_display():
             message = self.config.message
             if self.config.dynamic_source:

--- a/tests/test_alert_priorities.py
+++ b/tests/test_alert_priorities.py
@@ -1,0 +1,158 @@
+"""
+Tests for weather alert priority configuration and assignment.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+import json
+from datetime import datetime
+
+from led_kurokku.cli.models.weather import WeatherConfig, WeatherLocation
+from led_kurokku.cli.services.weather_service import WeatherService
+
+
+class TestAlertPriorities:
+    """Test alert priority configuration and assignment."""
+
+    def test_default_alert_priorities(self):
+        """Test that default alert priorities are configured correctly."""
+        config = WeatherConfig()
+        
+        # Test default configuration includes heat advisory at priority 10
+        assert "heat advisory" in config.alert_priorities
+        assert config.alert_priorities["heat advisory"] == 10
+        
+        # Test other default priorities
+        assert config.alert_priorities["excessive heat warning"] == 5
+        assert config.alert_priorities["winter storm warning"] == 1
+        assert config.alert_priorities["tornado warning"] == 1
+        assert config.alert_priorities["severe thunderstorm warning"] == 1
+
+    def test_get_alert_priority_exact_match(self):
+        """Test exact string matching for alert priorities."""
+        config = WeatherConfig()
+        
+        # Test exact matches
+        assert config.get_alert_priority("heat advisory") == 10
+        assert config.get_alert_priority("excessive heat warning") == 5
+        assert config.get_alert_priority("tornado warning") == 1
+
+    def test_get_alert_priority_case_insensitive(self):
+        """Test case-insensitive matching for alert priorities."""
+        config = WeatherConfig()
+        
+        # Test case variations
+        assert config.get_alert_priority("Heat Advisory") == 10
+        assert config.get_alert_priority("HEAT ADVISORY") == 10
+        assert config.get_alert_priority("hEaT aDvIsOrY") == 10
+        assert config.get_alert_priority("EXCESSIVE HEAT WARNING") == 5
+
+    def test_get_alert_priority_partial_match(self):
+        """Test partial string matching for alert priorities."""
+        config = WeatherConfig()
+        
+        # Test partial matches
+        assert config.get_alert_priority("Regional Heat Advisory") == 10
+        assert config.get_alert_priority("Extended Heat Advisory for Metro Area") == 10
+        assert config.get_alert_priority("Severe Thunderstorm Warning issued") == 1
+
+    def test_get_alert_priority_no_match(self):
+        """Test default priority for unmatched alert types."""
+        config = WeatherConfig()
+        
+        # Test alerts not in configuration (should default to priority 1)
+        assert config.get_alert_priority("Flood Warning") == 1
+        assert config.get_alert_priority("Dense Fog Advisory") == 1
+        assert config.get_alert_priority("Unknown Alert Type") == 1
+
+    def test_custom_alert_priorities(self):
+        """Test custom alert priority configuration."""
+        custom_priorities = {
+            "custom alert": 15,
+            "high priority alert": 2,
+            "flood warning": 8,
+        }
+        
+        config = WeatherConfig(alert_priorities=custom_priorities)
+        
+        # Test custom priorities
+        assert config.get_alert_priority("custom alert") == 15
+        assert config.get_alert_priority("high priority alert") == 2
+        assert config.get_alert_priority("flood warning") == 8
+        
+        # Test that non-configured alerts still default to 1
+        assert config.get_alert_priority("unknown alert") == 1
+
+    def test_alert_priorities_serialization(self):
+        """Test that alert priorities are properly serialized and deserialized."""
+        config = WeatherConfig()
+        
+        # Serialize to JSON
+        json_data = config.model_dump_json()
+        data = json.loads(json_data)
+        
+        # Check that alert_priorities are in the serialized data
+        assert "alert_priorities" in data
+        assert data["alert_priorities"]["heat advisory"] == 10
+        
+        # Deserialize back
+        restored_config = WeatherConfig.model_validate(data)
+        assert restored_config.get_alert_priority("heat advisory") == 10
+
+    def test_weather_service_priority_assignment(self):
+        """Test that WeatherService correctly assigns priorities to alerts."""
+        # Create a config with specific priorities
+        config = WeatherConfig(
+            alert_priorities={
+                "heat advisory": 10,
+                "tornado warning": 1,
+                "flood warning": 5,
+            }
+        )
+        
+        # Test various alert messages and their expected priorities
+        test_cases = [
+            ("Heat Advisory", 10),
+            ("Tornado Warning", 1),
+            ("Severe Thunderstorm Warning", 1),  # Default from config
+            ("Flood Warning", 5),
+            ("Dense Fog Advisory", 1),  # Not configured, should default to 1
+            ("Regional Heat Advisory for Metro Area", 10),  # Partial match
+        ]
+        
+        for alert_message, expected_priority in test_cases:
+            actual_priority = config.get_alert_priority(alert_message)
+            assert actual_priority == expected_priority, \
+                f"Alert '{alert_message}' should have priority {expected_priority}, got {actual_priority}"
+
+    def test_alert_priority_edge_cases(self):
+        """Test edge cases for alert priority assignment."""
+        config = WeatherConfig()
+        
+        # Test empty string
+        assert config.get_alert_priority("") == 1
+        
+        # Test whitespace only
+        assert config.get_alert_priority("   ") == 1
+        
+        # Test very long string with match
+        long_string = "This is a very long alert message that contains heat advisory somewhere in the middle"
+        assert config.get_alert_priority(long_string) == 10
+        
+        # Test string with special characters
+        assert config.get_alert_priority("Heat Advisory - Updated!") == 10
+
+    def test_multiple_partial_matches(self):
+        """Test behavior when multiple configured alerts match."""
+        config = WeatherConfig(
+            alert_priorities={
+                "heat": 10,
+                "heat advisory": 15,
+                "advisory": 5,
+            }
+        )
+        
+        # Should match the first one found (depends on dict iteration order)
+        # This tests that the method handles multiple matches gracefully
+        priority = config.get_alert_priority("heat advisory")
+        assert priority in [10, 15, 5]  # Any of these is acceptable behavior


### PR DESCRIPTION
* standardize on pycron usage for cron config strings and add to base widget config.
* weather priority stuff so that `heat advisory` only displays every 10 minutes.